### PR TITLE
#30 restructure app folders, add breadcrumbs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "react-dom": "^18",
         "react-hook-form": "^7.52.0",
         "react-icons": "^5.2.1",
+        "sass": "^1.77.6",
         "tailwind-merge": "^2.3.0",
         "tailwindcss-animate": "^1.0.7",
         "zod": "^3.23.8"
@@ -1172,23 +1173,6 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-slot": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.0.tgz",
-      "integrity": "sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.0"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-use-callback-ref": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
@@ -1700,23 +1684,6 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-slot": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.0.tgz",
-      "integrity": "sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.0"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
@@ -3279,6 +3246,11 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immutable": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.6.tgz",
+      "integrity": "sha512-Ju0+lEMyzMVZarkTn/gqRpdqd5dOPaz1mCZ0SH3JV6iFw81PldE/PEB1hWVEA288HPt4WXW8O7AWxB10M+03QQ=="
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -4257,6 +4229,22 @@
       ],
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/sass": {
+      "version": "1.77.6",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.6.tgz",
+      "integrity": "sha512-ByXE1oLD79GVq9Ht1PeHWCPMPB8XHpBuz1r85oByKHjZY6qV6rWnQovQzXJXuQ/XyE1Oj3iPk3lo28uzaRA2/Q==",
+      "dependencies": {
+        "chokidar": ">=3.0.0 <4.0.0",
+        "immutable": "^4.0.0",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/scheduler": {

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "@radix-ui/react-select": "^2.0.0",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-switch": "^1.0.3",
-    "@radix-ui/react-toast": "^1.1.5",
     "@radix-ui/react-tabs": "^1.1.0",
+    "@radix-ui/react-toast": "^1.1.5",
     "@supabase/supabase-js": "^2.43.5",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
@@ -32,6 +32,7 @@
     "react-dom": "^18",
     "react-hook-form": "^7.52.0",
     "react-icons": "^5.2.1",
+    "sass": "^1.77.6",
     "tailwind-merge": "^2.3.0",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^3.23.8"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,20 +1,25 @@
 import { PetGrid } from '@/components/PetGrid';
 import { AddPetModal } from '@/components/modals/AddPetModal';
 import { Toaster } from '@/components/ui/toaster';
+import { font_accent } from '@/components/ui/fonts';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import '@/app/styles/main.scss';
 
 export default function Home() {
   return (
-    <>
-      <header className="flex justify-end p-5 px-24">
-        {/* ShadCN's modal component has the button that calls the modal inside the modalcomponent, which can be confusing */}
-        {/* that's why there is a AddPetModal here, and not the button */}
-        {/* https://ui.shadcn.com/docs/components/dialog */}
-        <AddPetModal />
-      </header>
-      <main className="flex min-h-screen flex-col items-center justify-between p-24">
-        <PetGrid />
+    <div className="grid place-items-center h-[100vh] text-center doors-of-durin">
+      <main className="text-center">
+        <h1 className={`${font_accent.className} font-semibold text-3xl`}>
+          Pet app home page
+        </h1>
+        <div>
+          <p>Speak, friend, and</p>
+          <Link href="user">
+            <Button>Enter</Button>
+          </Link>
+        </div>
       </main>
-      <Toaster />
-    </>
+    </div>
   );
 }

--- a/src/app/styles/_home.scss
+++ b/src/app/styles/_home.scss
@@ -1,0 +1,14 @@
+.doors-of-durin {
+  background-image: url('https://tolkiengateway.net/w/images/e/ea/J.R.R._Tolkien_-_Doors_of_Durin.jpg');
+  background-position: center;
+  background-size: contain;
+  background-repeat: no-repeat;
+  main {
+    background-color: #ffffff72;
+    padding: 3rem;
+    border-radius: 1rem;
+    -webkit-backdrop-filter: blur(5px);
+    backdrop-filter: blur(5px);
+    border: 1px solid black;
+  }
+}

--- a/src/app/styles/main.scss
+++ b/src/app/styles/main.scss
@@ -1,0 +1,1 @@
+@import 'home.scss';

--- a/src/app/user/layout.tsx
+++ b/src/app/user/layout.tsx
@@ -1,0 +1,14 @@
+import { BreadCrumbs } from '@/components/BreadCrumbs';
+import { Toaster } from '@/components/ui/toaster';
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="w-[80vw] mx-auto">
+      <div>
+        <BreadCrumbs />
+      </div>
+      <div>{children}</div>
+      <Toaster />
+    </div>
+  );
+}

--- a/src/app/user/page.tsx
+++ b/src/app/user/page.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { PetGrid } from '@/components/PetGrid';
+import { AddPetModal } from '@/components/modals/AddPetModal';
+
+const page = () => {
+  return (
+    <div>
+      <div className="flex justify-end py-4">
+        {/* ShadCN's modal component has the button that calls the modal inside the modalcomponent, which can be confusing */}
+        {/* that's why there is a AddPetModal here, and not the button */}
+        {/* https://ui.shadcn.com/docs/components/dialog */}
+        <AddPetModal />
+      </div>
+      <PetGrid />
+    </div>
+  );
+};
+
+export default page;

--- a/src/components/BreadCrumbs.tsx
+++ b/src/components/BreadCrumbs.tsx
@@ -1,0 +1,24 @@
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from '@/components/ui/breadcrumb';
+
+export const BreadCrumbs = () => {
+  return (
+    <Breadcrumb className="py-2">
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="/user">List of Pets</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>Pet Page</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+};

--- a/src/components/PetCard.tsx
+++ b/src/components/PetCard.tsx
@@ -40,8 +40,8 @@ export const PetCard = ({
   const age = calculateAge(date_of_birth, currentDate);
 
   return (
-    <Link href={`/pets/${id}`}>
-      <Card className="w-[300px] h-[350px] relative">
+    <Link href={`/user/pets/${id}`}>
+      <Card className="h-[350px] relative">
         <CardHeader>
           <PetCardImage img={img} alt={name} />
           <div className="relative z-1 p-4 min-h-[33%] bg-black backdrop-blur-sm bg-opacity-60 rounded-b-xl flex flex-col justify-between">

--- a/src/components/PetGrid.tsx
+++ b/src/components/PetGrid.tsx
@@ -8,7 +8,7 @@ export const PetGrid = async () => {
   }
 
   return (
-    <div className="flex flex-wrap items-center justify-center gap-4">
+    <div className="grid sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
       {pets.map((pet) => (
         <PetCard key={pet.name} {...pet} />
       ))}

--- a/src/components/ui/breadcrumb.tsx
+++ b/src/components/ui/breadcrumb.tsx
@@ -1,0 +1,115 @@
+import * as React from "react"
+import { ChevronRightIcon, DotsHorizontalIcon } from "@radix-ui/react-icons"
+import { Slot } from "@radix-ui/react-slot"
+
+import { cn } from "@/lib/utils"
+
+const Breadcrumb = React.forwardRef<
+  HTMLElement,
+  React.ComponentPropsWithoutRef<"nav"> & {
+    separator?: React.ReactNode
+  }
+>(({ ...props }, ref) => <nav ref={ref} aria-label="breadcrumb" {...props} />)
+Breadcrumb.displayName = "Breadcrumb"
+
+const BreadcrumbList = React.forwardRef<
+  HTMLOListElement,
+  React.ComponentPropsWithoutRef<"ol">
+>(({ className, ...props }, ref) => (
+  <ol
+    ref={ref}
+    className={cn(
+      "flex flex-wrap items-center gap-1.5 break-words text-sm text-muted-foreground sm:gap-2.5",
+      className
+    )}
+    {...props}
+  />
+))
+BreadcrumbList.displayName = "BreadcrumbList"
+
+const BreadcrumbItem = React.forwardRef<
+  HTMLLIElement,
+  React.ComponentPropsWithoutRef<"li">
+>(({ className, ...props }, ref) => (
+  <li
+    ref={ref}
+    className={cn("inline-flex items-center gap-1.5", className)}
+    {...props}
+  />
+))
+BreadcrumbItem.displayName = "BreadcrumbItem"
+
+const BreadcrumbLink = React.forwardRef<
+  HTMLAnchorElement,
+  React.ComponentPropsWithoutRef<"a"> & {
+    asChild?: boolean
+  }
+>(({ asChild, className, ...props }, ref) => {
+  const Comp = asChild ? Slot : "a"
+
+  return (
+    <Comp
+      ref={ref}
+      className={cn("transition-colors hover:text-foreground", className)}
+      {...props}
+    />
+  )
+})
+BreadcrumbLink.displayName = "BreadcrumbLink"
+
+const BreadcrumbPage = React.forwardRef<
+  HTMLSpanElement,
+  React.ComponentPropsWithoutRef<"span">
+>(({ className, ...props }, ref) => (
+  <span
+    ref={ref}
+    role="link"
+    aria-disabled="true"
+    aria-current="page"
+    className={cn("font-normal text-foreground", className)}
+    {...props}
+  />
+))
+BreadcrumbPage.displayName = "BreadcrumbPage"
+
+const BreadcrumbSeparator = ({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"li">) => (
+  <li
+    role="presentation"
+    aria-hidden="true"
+    className={cn("[&>svg]:size-3.5", className)}
+    {...props}
+  >
+    {children ?? <ChevronRightIcon />}
+  </li>
+)
+BreadcrumbSeparator.displayName = "BreadcrumbSeparator"
+
+const BreadcrumbEllipsis = ({
+  className,
+  ...props
+}: React.ComponentProps<"span">) => (
+  <span
+    role="presentation"
+    aria-hidden="true"
+    className={cn("flex h-9 w-9 items-center justify-center", className)}
+    {...props}
+  >
+    <DotsHorizontalIcon className="h-4 w-4" />
+    <span className="sr-only">More</span>
+  </span>
+)
+BreadcrumbEllipsis.displayName = "BreadcrumbElipssis"
+
+export {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  BreadcrumbEllipsis,
+}

--- a/src/pages/user/pets/[id].js
+++ b/src/pages/user/pets/[id].js
@@ -5,6 +5,8 @@
 import React from 'react';
 import '@/app/globals.css';
 import { supabase } from '@/services/supabase';
+
+import { BreadCrumbs } from '@/components/BreadCrumbs';
 import { PetTabs } from '@/components/PetTabs';
 import { ButtonsOnPetPage } from '@/components/ButtonsOnPetPage';
 
@@ -43,6 +45,9 @@ export async function getStaticProps({ params }) {
 export default function PetPage({ pet }) {
   return (
     <div className="w-[80vw] mx-auto">
+      <div>
+        <BreadCrumbs />
+      </div>
       <ButtonsOnPetPage />
       <PetTabs {...pet} />
     </div>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "src/pages/pets/[id].js"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "src/pages/user/pets/[id].js"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
- **Restructured the folders a bit, to have a better idea how the app will be structured**

Now the main view with the pet grid has a route `/user` - it will be `/[user-id]` once we set up authentication
(the main page at `/` is a mock, will rework that on another branch)

- **Added breadcrumbs component and added them to the main layout**

Breadcrumbs have hardcoded links for now. Cannot implement dynamic links without proper routing in place, and routing is kinda blocked by the authenthication (`/user/[pet-id]`)
