### PR TITLE
44 pet name ellipsis, age

### DIFF
--- a/src/app/styles/_icons.scss
+++ b/src/app/styles/_icons.scss
@@ -1,0 +1,4 @@
+.icon-sm {
+    font-size: 1rem;
+    color: $color-primary;
+}

--- a/src/app/styles/_variables.scss
+++ b/src/app/styles/_variables.scss
@@ -1,0 +1,1 @@
+$color-primary: #A37E57;

--- a/src/app/styles/main.scss
+++ b/src/app/styles/main.scss
@@ -1,1 +1,3 @@
-@import 'home.scss';
+@import 'variables';
+@import 'icons';
+@import 'home';

--- a/src/components/PetCard.tsx
+++ b/src/components/PetCard.tsx
@@ -48,24 +48,40 @@ export const PetCard = ({
             <CardTitle
               className={`${font_accent.className} font-semibold text-3xl flex justify-between items-center`}
             >
-              <div className="text-ellipsis overflow-hidden whitespace-nowrap" title={pet_name}>{pet_name}</div>
+              <div
+                className="text-ellipsis overflow-hidden whitespace-nowrap"
+                title={pet_name}
+              >
+                {pet_name}
+              </div>
               <div>
                 <TbAlertCircle className="text-danger" />
               </div>
             </CardTitle>
             <p>{breed}</p>
-            <div className="flex justify-between items-center ">
+            <div className="flex justify-between items-center gap-3 uppercase">
               {sex ? (
                 <CardDescription className="flex items-center gap-1">
-                  {isMale ? <TbGenderMale /> : <TbGenderFemale />}
+                  {isMale ? (
+                    <TbGenderMale className="icon-sm" />
+                  ) : (
+                    <TbGenderFemale className="icon-sm" />
+                  )}
                   <span>{isMale ? 'Male' : 'Female'}</span>
                 </CardDescription>
               ) : null}
 
-              <CardDescription className="flex items-center gap-1">
-                <TbClockHour3 />
-                {age}
-              </CardDescription>
+              <div
+                className="flex items-center gap-1 overflow-hidden"
+                title={age}
+              >
+                <CardDescription>
+                  <TbClockHour3 className="icon-sm" />
+                </CardDescription>
+                <CardDescription className="overflow-hidden text-ellipsis whitespace-nowrap">
+                  {age}
+                </CardDescription>
+              </div>
             </div>
           </div>
         </CardHeader>

--- a/src/components/PetCard.tsx
+++ b/src/components/PetCard.tsx
@@ -48,9 +48,10 @@ export const PetCard = ({
             <CardTitle
               className={`${font_accent.className} font-semibold text-3xl flex justify-between items-center`}
             >
-              {pet_name}
-
-              <TbAlertCircle className="text-danger" />
+              <div className="text-ellipsis overflow-hidden whitespace-nowrap" title={pet_name}>{pet_name}</div>
+              <div>
+                <TbAlertCircle className="text-danger" />
+              </div>
             </CardTitle>
             <p>{breed}</p>
             <div className="flex justify-between items-center ">

--- a/src/components/PetCard.tsx
+++ b/src/components/PetCard.tsx
@@ -49,7 +49,7 @@ export const PetCard = ({
               className={`${font_accent.className} font-semibold text-3xl flex justify-between items-center`}
             >
               <div
-                className="text-ellipsis overflow-hidden whitespace-nowrap"
+                className="truncate"
                 title={pet_name}
               >
                 {pet_name}
@@ -78,7 +78,7 @@ export const PetCard = ({
                 <CardDescription>
                   <TbClockHour3 className="icon-sm" />
                 </CardDescription>
-                <CardDescription className="overflow-hidden text-ellipsis whitespace-nowrap">
+                <CardDescription className="truncate">
                   {age}
                 </CardDescription>
               </div>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5eb138eb-f14e-4206-855a-9c84e5601f28)

* when pet name is too long, it gets a "..."
* when pet age gets too long, it also gets "..."
* full info is shown on hovering over the name and age in a `title` attribute (it was a simple thing to do and remains accessible)
* icons were coloured and text got uppercase to keep up with the design

I wrapped pet age in ellipsis because when it was too long (for ages < 2 years, when we show it a format "x years, y months") it was making the card grid look inconsistent, and inconsistent = messy. Now the UI looks cleaner.